### PR TITLE
Added missing include for linux build

### DIFF
--- a/linux/obd.c
+++ b/linux/obd.c
@@ -13,5 +13,6 @@
 #define HIGH 1
 #define LOW 0
 #include "../src/OneBitDisplay.h"
+#include "../src/obd_io.inl"
 #include "../src/obd.inl"
 


### PR DESCRIPTION
Hi, I was trying to build the library on Linux and realized there is probably missing include which causes undeclared errors.

Reproduce:
```
cd linux
sudo make
```

```
pi@raspberrypi:~/git/OneBitDisplay/linux $ sudo make
cc -c -Wall -O2 -I../src -DSPI_BUS_NUMBER=0 -D_LINUX_ obd.c
In file included from obd.c:16:
../src/obd.inl: In function ‘obdCachedFlush’:
../src/obd.inl:1373:8: error: ‘u8End’ undeclared (first use in this function)
    if (u8End > 0) {
        ^~~~~
../src/obd.inl:1373:8: note: each undeclared identifier is reported only once for each function it appears in
../src/obd.inl:1374:31: error: ‘u8Cache’ undeclared (first use in this function)
       obdWriteDataBlock(pOBD, u8Cache, u8End, bRender);
                               ^~~~~~~
../src/obd.inl: In function ‘obdCachedWrite’:
../src/obd.inl:1381:8: error: ‘u8End’ undeclared (first use in this function)
    if (u8End + u8Len > MAX_CACHE) // need to flush it
        ^~~~~
../src/obd.inl:1381:24: error: ‘MAX_CACHE’ undeclared (first use in this function)
    if (u8End + u8Len > MAX_CACHE) // need to flush it
                        ^~~~~~~~~
../src/obd.inl:1385:12: error: ‘u8Cache’ undeclared (first use in this function)
    memcpy(&u8Cache[u8End], pData, u8Len);
            ^~~~~~~
../src/obd.inl: In function ‘obdWriteLCDLine’:
../src/obd.inl:1459:7: warning: implicit declaration of function ‘digitalWrite’; did you mean ‘RawWrite’? [-Wimplicit-function-declaration]
       digitalWrite(pOBD->iCSPin, HIGH); // active high
       ^~~~~~~~~~~~
       RawWrite
../src/obd.inl:1470:21: warning: implicit declaration of function ‘pgm_read_byte’ [-Wimplicit-function-declaration]
      ucLineBuf[1] = pgm_read_byte(&ucMirror[iLine+1]); // current line number
                     ^~~~~~~~~~~~~
../src/obd.inl: In function ‘LCDPowerUp’:
../src/obd.inl:1526:5: error: ‘u8Cache’ undeclared (first use in this function)
     u8Cache[0] = 0x00; // send everything in command mode
     ^~~~~~~
../src/obd.inl: In function ‘EPDSendCMDSequence’:
../src/obd.inl:1567:22: error: ‘u8Cache’ undeclared (first use in this function)
             memcpy_P(u8Cache, s, iLen-1);
                      ^~~~~~~
../src/obd.inl: In function ‘obdSPIInit’:
../src/obd.inl:1791:9: warning: implicit declaration of function ‘pinMode’ [-Wimplicit-function-declaration]
         pinMode(pOBD->iDCPin, OUTPUT);
         ^~~~~~~
../src/obd.inl:2146:16: error: ‘u8Cache’ undeclared (first use in this function)
       memcpy_P(u8Cache, s, iLen); // do it from RAM
                ^~~~~~~
../src/obd.inl: In function ‘EPDWaitBusy’:
../src/obd.inl:2563:10: warning: implicit declaration of function ‘digitalRead’ [-Wimplicit-function-declaration]
      if (digitalRead(pOBD->iLEDPin) == pOBD->busy_idle)
          ^~~~~~~~~~~
../src/obd.inl: In function ‘EPDDumpFast’:
../src/obd.inl:2856:65: error: ‘false’ undeclared (first use in this function); did you mean ‘pause’?
             EPD213_Begin(pOBD, 0, 0, pOBD->width, pOBD->height, false);
                                                                 ^~~~~
                                                                 pause
../src/obd.inl:2863:40: error: ‘true’ undeclared (first use in this function); did you mean ‘free’?
         EPD213_Begin(pOBD, x, y, w, h, true);
                                        ^~~~
                                        free
../src/obd.inl: In function ‘EPD213_Begin’:
../src/obd.inl:2940:18: error: ‘u8Cache’ undeclared (first use in this function)
         memcpy_P(u8Cache, epd213_lut2_partial, sizeof(epd213_lut2_partial));
                  ^~~~~~~
../src/obd.inl: In function ‘EPD154_Begin’:
../src/obd.inl:2997:18: error: ‘u8Cache’ undeclared (first use in this function)
         memcpy_P(u8Cache, lut154_partial_update, sizeof(lut154_partial_update));
                  ^~~~~~~
../src/obd.inl: In function ‘EPDWriteImage’:
../src/obd.inl:3171:3: error: ‘u8Cache’ undeclared (first use in this function)
   u8Cache[0] = u8Cache[1] = 0; // prefix for IT8951
   ^~~~~~~
../src/obd.inl: In function ‘EPD293_Begin’:
../src/obd.inl:3430:18: error: ‘u8Cache’ undeclared (first use in this function)
         memcpy_P(u8Cache, epd293_lut_partial, sizeof(epd293_lut_partial));
                  ^~~~~~~
../src/obd.inl: In function ‘EPDDumpBuffer’:
../src/obd.inl:3549:28: error: ‘false’ undeclared (first use in this function); did you mean ‘pause’?
         EPD27_SetLut(pOBD, false);
                            ^~~~~
                            pause
../src/obd.inl: In function ‘obdDumpPartial’:
../src/obd.inl:4018:27: error: ‘false’ undeclared (first use in this function); did you mean ‘pause’?
         EPDWaitBusy(pOBD, false);
                           ^~~~~
                           pause
../src/obd.inl:3976:13: warning: variable ‘ucCMD1’ set but not used [-Wunused-but-set-variable]
     uint8_t ucCMD1, ucCMD2;
             ^~~~~~
../src/obd.inl: In function ‘obdDumpFast’:
../src/obd.inl:4034:40: error: ‘true’ undeclared (first use in this function); did you mean ‘free’?
             return EPDDumpBuffer(pOBD, true);
                                        ^~~~
                                        free
../src/obd.inl: In function ‘obdDumpBuffer_2’:
../src/obd.inl:4086:21: error: ‘u8Cache’ undeclared (first use in this function)
                     u8Cache[pOBD->width-1-x] = ucMirror[pBuffer[x]];
                     ^~~~~~~
../src/obd.inl: In function ‘obdDumpBuffer’:
../src/obd.inl:4149:43: error: ‘true’ undeclared (first use in this function); did you mean ‘free’?
     return obdDumpBuffer_2(pOBD, pBuffer, true);
                                           ^~~~
                                           free
../src/obd.inl: In function ‘obdLoadBMP’:
../src/obd.inl:4935:20: error: ‘false’ undeclared (first use in this function); did you mean ‘pause’?
 uint8_t bFlipped = false;
                    ^~~~~
                    pause
../src/obd.inl:4955:19: error: ‘true’ undeclared (first use in this function); did you mean ‘free’?
   else bFlipped = true;
                   ^~~~
                   free
../src/obd.inl:4982:13: error: ‘u8Cache’ undeclared (first use in this function)
         d = u8Cache;
             ^~~~~~~
../src/obd.inl: In function ‘obdLoadBMP3’:
../src/obd.inl:5052:20: error: ‘false’ undeclared (first use in this function); did you mean ‘pause’?
 uint8_t bFlipped = false;
                    ^~~~~
                    pause
../src/obd.inl:5074:20: error: ‘true’ undeclared (first use in this function); did you mean ‘free’?
         bFlipped = true;
                    ^~~~
                    free
../src/obd.inl: In function ‘obdWriteString’:
../src/obd.inl:5294:14: error: ‘u8Temp’ undeclared (first use in this function); did you mean ‘usleep’?
              u8Temp[0] = 0; // first column is blank
              ^~~~~~
              usleep
../src/obd.inl: In function ‘obdWriteStringCustom’:
../src/obd.inl:5695:19: error: ‘u8Cache’ undeclared (first use in this function)
            memset(u8Cache, ucFill, sizeof(u8Cache));
                   ^~~~~~~
../src/obd.inl: In function ‘obdFill’:
../src/obd.inl:5835:10: error: ‘u8Cache’ undeclared (first use in this function)
   memset(u8Cache, ucData, iCols);
          ^~~~~~~
../src/obd.inl: In function ‘obdDrawLine’:
../src/obd.inl:5913:16: error: ‘u8Cache’ undeclared (first use in this function)
         memset(u8Cache, ucFill, sizeof(u8Cache));
                ^~~~~~~
In file included from obd.c:16:
obd.c: At top level:
../src/obd.inl:26:13: warning: ‘RawWrite’ used but never defined
 static void RawWrite(OBDISP *pOBD, unsigned char *pData, int iLen);
             ^~~~~~~~
../src/obd.inl:27:13: warning: ‘RawWriteData’ used but never defined
 static void RawWriteData(OBDISP *pOBD, unsigned char *pData, int iLen);
             ^~~~~~~~~~~~
In file included from obd.c:16:
../src/obd.inl: In function ‘obdDumpFast’:
../src/obd.inl:4039:1: warning: control reaches end of non-void function [-Wreturn-type]
 } /* obdDumpFast() */
 ^
../src/obd.inl: In function ‘obdDumpBuffer’:
../src/obd.inl:4150:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
make: *** [Makefile:12: obd.o] Error 1
pi@raspberrypi:~/git/OneBitDisplay/linux $ cd ..
pi@raspberrypi:~/git/OneBitDisplay $ git stash pop
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

        modified:   linux/obd.c

Untracked files:
  (use "git add <file>..." to include in what will be committed)

        linux/libOneBitDisplay.a
        linux/obd.o

no changes added to commit (use "git add" and/or "git commit -a")
Dropped refs/stash@{0} (b07fdfcdbe1e6c8666ad93c838c3adde68045bb6)
pi@raspberrypi:~/git/OneBitDisplay $ cd linux
pi@raspberrypi:~/git/OneBitDisplay/linux $ sudo make
cc -c -Wall -O2 -I../src -DSPI_BUS_NUMBER=0 -D_LINUX_ obd.c
In file included from obd.c:17:
../src/obd.inl: In function ‘obdDumpPartial’:
../src/obd.inl:3976:13: warning: variable ‘ucCMD1’ set but not used [-Wunused-but-set-variable]
     uint8_t ucCMD1, ucCMD2;
             ^~~~~~
In file included from obd.c:16:
At top level:
../src/obd_io.inl:199:16: warning: ‘pgm_read_word’ defined but not used [-Wunused-function]
 static int16_t pgm_read_word(const uint8_t *ptr)
                ^~~~~~~~~~~~~


^Cmake: *** wait: No child processes.  Stop.
make: *** Waiting for unfinished jobs....
make: *** wait: No child processes.  Stop.
pi@raspberrypi:~/git/OneBitDisplay/linux $ ^C
pi@raspberrypi:~/git/OneBitDisplay/linux $ cd ..
pi@raspberrypi:~/git/OneBitDisplay $ git diff
diff --git a/linux/obd.c b/linux/obd.c
index 59022a0..662a026 100644
--- a/linux/obd.c
+++ b/linux/obd.c
@@ -13,5 +13,6 @@
 #define HIGH 1
 #define LOW 0
 #include "../src/OneBitDisplay.h"
+#include "../src/obd_io.inl"
 #include "../src/obd.inl"
```